### PR TITLE
Disable by default the collection of metrics of NFSv4 operations per client.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prometheus-linux-nfsdv4-exporter"
-version = "1.1.3"
+version = "1.1.4"
 edition = "2018"
 license = "BSD-2-Clause"
 description = "prometheus nfsv4 exporter"

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ use crate::utils::helper::{is_kernel_compatible};
 mod prometheus;
 use crate::prometheus::exporter::{start_prometheus};
 
-const VERSION: &str = "1.0.1";
+const VERSION: &str = "1.1.4";
 
 fn help() {
      println!("Use command with help option");
@@ -74,6 +74,14 @@ fn main() {
                         .required(false)
                         .value_name("PORT")
                         .takes_value(true),
+                )
+                .arg(
+                    Arg::with_name("nfsv4opsclients")
+                        .help("Enable NFSv4 metrics operations per client (WARNING: can be CPU intensive)")
+                        .short("o")
+                        .long("nfsv4-ops-clients")
+                        .required(false)
+                        .takes_value(false),
                 ),
         )
         .get_matches();


### PR DESCRIPTION
It can be CPU intensive if the NFSv4 server has many clients doing many operations per second.

To enable the collection of these metrics, a new FLAG was added: ./prometheus-linux-nfsdv4-exporter set -o
For more information: ./prometheus-linux-nfsdv4-exporter set -h